### PR TITLE
user-story/120/task/121/html-to-markdown

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7832,6 +7832,11 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -11563,6 +11568,53 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+          "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -12508,6 +12560,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,14 @@
     "@material-ui/icons": "^4.5.1",
     "bootstrap": "^4.3.1",
     "jest": "^24.9.0",
+    "jquery": "^3.4.1",
     "materialize-css": "^1.0.0-rc.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-scripts": "3.2.0",
-    "react-test-renderer": "^16.11.0"
+    "react-test-renderer": "^16.11.0",
+    "showdown": "^1.9.1",
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/__tests__/Article.test.js
+++ b/frontend/src/__tests__/Article.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Article from '../components/Article';
+import { markdown2html } from '../components/Article';
+
+it('renders article component', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<Article />, div);
+    ReactDOM.unmountComponentAtNode(div);
+});
+
+it('converts markdown to html', () => {
+
+    const dummyMarkdown = `# Hello
+This is some markdown test
+
+## This markdown test should render properly
+These are some bullet points
+- Hello!
+- Welcome!
+`
+expect(markdown2html(dummyMarkdown)).toMatchSnapshot()
+
+});

--- a/frontend/src/components/Article.js
+++ b/frontend/src/components/Article.js
@@ -1,6 +1,12 @@
 import React, { Component } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import { Converter } from 'showdown';
+
+
+function markdown2html(markdown) {
+    return new Converter().makeHtml(markdown);
+}
 
 const useStyles = makeStyles({
     root: {
@@ -53,8 +59,7 @@ const ArticleComponent = (props) => {
                 <Typography variant="h5" className={classes.author}>
                     {props.author}
                 </Typography>
-                <Typography variant="body1" className={classes.articleBody}>
-                    {props.body}
+                <Typography variant="body1" className={classes.articleBody} dangerouslySetInnerHTML={{__html:markdown2html(props.body)}}>
                 </Typography>
 
             </div>
@@ -63,11 +68,7 @@ const ArticleComponent = (props) => {
 }
 
 class Article extends Component {
-    constructor(props) {
-        super(props)
-        console.log(props)
-    }
-
+    
     render() {
         return (
             <ArticleComponent props={this.props} />
@@ -80,8 +81,10 @@ Article.defaultProps = {
     title: "Dummy Title goes here and here and here",
     teaser: "A teaser for the dummy article here.Integer laoreet, felis vitae tempor ultricies, quam metus condimentum massa, sed porttitor ante sapien nec nibh. Nam dictum vel augue non gravida. ",
     author: "Dummy Author 1",
-    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum nec pretium nisl, eleifend pellentesque metus. Quisque maximus leo purus, non tempus enim blandit quis. Sed at tristique nulla. Suspendisse pulvinar quam nibh, a posuere sapien scelerisque at. Nunc elementum dolor in facilisis auctor. Maecenas faucibus diam at ante euismod, vitae lobortis justo auctor. In dignissim urna a massa pulvinar, et pulvinar ligula auctor. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc ullamcorper leo a magna posuere, sed pretium enim consectetur. Etiam dignissim blandit aliquet. Proin in ullamcorper quam, sed tincidunt nulla. Aliquam eget quam ullamcorper, porttitor nisi non, congue urna. Suspendisse a eleifend libero, tempus fermentum ex. Nulla leo felis, vulputate vitae viverra ut, mattis a massa. \n
+    body: `## Some subtitle
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum nec pretium nisl, eleifend pellentesque metus. Quisque maximus leo purus, non tempus enim blandit quis. Sed at tristique nulla. Suspendisse pulvinar quam nibh, a posuere sapien scelerisque at. Nunc elementum dolor in facilisis auctor. Maecenas faucibus diam at ante euismod, vitae lobortis justo auctor. In dignissim urna a massa pulvinar, et pulvinar ligula auctor. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc ullamcorper leo a magna posuere, sed pretium enim consectetur. Etiam dignissim blandit aliquet. Proin in ullamcorper quam, sed tincidunt nulla. Aliquam eget quam ullamcorper, porttitor nisi non, congue urna. Suspendisse a eleifend libero, tempus fermentum ex. Nulla leo felis, vulputate vitae viverra ut, mattis a massa. \n
 
+### There is another subtitle
 Cras bibendum tempor mi ut vehicula. Quisque id risus ut mauris ultrices porttitor. Curabitur tristique nisl vel odio sagittis tristique. Praesent blandit lorem risus, ac imperdiet metus tincidunt dignissim. Praesent sollicitudin purus nisi, nec suscipit sem tempus viverra. Suspendisse sed venenatis risus, eu ultrices felis. Mauris luctus, lectus et fringilla eleifend, lorem tellus placerat velit, sed euismod purus orci quis justo. Mauris at odio scelerisque, eleifend leo sed, volutpat augue. Sed rhoncus mattis arcu vitae feugiat. Integer pellentesque tempor felis quis feugiat. Donec eu volutpat dui.
 
 Integer molestie ultricies odio. Sed id leo ac libero sollicitudin gravida sed ut arcu. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut et dolor vel nisi volutpat dapibus at in lacus. Ut ut leo tempus, cursus lacus quis, lobortis nisl. Curabitur bibendum neque erat, et pharetra dui aliquam sed. Integer lacinia lacus egestas erat gravida, quis bibendum eros eleifend. Curabitur posuere libero tellus, id pellentesque nibh luctus a. Ut efficitur tristique magna quis pellentesque.
@@ -92,3 +95,5 @@ Integer laoreet, felis vitae tempor ultricies, quam metus condimentum massa, sed
 }
 
 export default Article
+
+export { markdown2html }


### PR DESCRIPTION
Notes: 
- I used `dangerouslySetInnerHtml` to inject the converted HTML. This comes with warnings of being able to inject scripts, but since we have only admins and writers write the content of the articles, the danger level is lesser. However, on the admin interface, we should add a task to sanitize the input that is stored in the database. 
- It currently runs on the client-side, but the functionality can be ported to run on the server-side too (ie, render on the server-side rather than the client) - I feel like the client is better for now since the server will not have the additional load of rendering markdown to HTML. If we change this later, I will rewrite the code to work on server-side